### PR TITLE
Permalink

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,7 +57,7 @@
 				</object>
 			</a>
 		</div>
-		<div id='copyModal' style='display: none'>
+		<div id='copyInputContainer' style='display: none'>
 			<input id='copyShareLinkInput' type='text' />
 		</div>
 		<script src='primerpedia.js'></script>

--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
 		<h2 id='article-title' style='display:none'>
 			<a id='viewlink' href=''></a>
 			<div class='actionlink-container'>
-				<a id='copysharelink' class='actionlink' href='#' title='copy share URL'>&#128203;</a>
+				<a id='copysharelink' class='actionlink' title='copy share URL'>&#128203;</a>
 				<a id='editlink' class='actionlink' href='' title='improve this!'>✎</a>
 			</div>
 		</h2>

--- a/index.html
+++ b/index.html
@@ -22,6 +22,7 @@
 		<h2 id='article-title' style='display:none'>
 			<a id='viewlink' href=''></a>
 			<div class='actionlink-container'>
+				<a id='copysharelink' class='actionlink' href='#' title='copy share URL'>&#128203;</a>
 				<a id='editlink' class='actionlink' href='' title='improve this!'>✎</a>
 			</div>
 		</h2>
@@ -55,6 +56,9 @@
 					<img src='img/info.png' alt='information icon' />
 				</object>
 			</a>
+		</div>
+		<div id='copyModal' style='display: none'>
+			<input id='copyShareLinkInput' type='text' />
 		</div>
 		<script src='primerpedia.js'></script>
 	</body>

--- a/index.html
+++ b/index.html
@@ -21,7 +21,9 @@
 		</div>
 		<h2 id='article-title' style='display:none'>
 			<a id='viewlink' href=''></a>
-			<a id='editlink' href='' title='improve this!'>✎</a>
+			<div class='actionlink-container'>
+				<a id='editlink' class='actionlink' href='' title='improve this!'>✎</a>
+			</div>
 		</h2>
 		<div id='content'>
 			<p>Primerpedia is a proof-of-concept demo for the

--- a/primerpedia.css
+++ b/primerpedia.css
@@ -122,6 +122,10 @@ object {
 	color: gray;
 }
 
+a#copysharelink {
+	cursor: pointer;
+}
+
 @media (min-width: 600px) {
     html {
         font-size: calc(13px + 0.5vw);

--- a/primerpedia.css
+++ b/primerpedia.css
@@ -68,9 +68,9 @@ a:active {
 	outline: none; /* don't show the dotted border on a clicked link */
 }
 
-#editlink {
+a.actionlink {
+	display: inline-block;
 	/* shape */
-	float: right;
 	padding: 0.5em 1em;
 	line-height: 0.5;
 	/* appearance */
@@ -88,17 +88,21 @@ a:active {
 	                               /* one pointing down-right and mirror it */
 }
 
-#editlink:hover {
+a.actionlink:hover {
 	background-color: #76b347;
 	background: linear-gradient(to bottom, #76b347 0%, #5e9e2e 100%);
 	box-shadow: inset 0 1px 0 0 #8dbf67;
 	text-decoration: none;
 }
 
-#editlink:active {
+a.actionlink:active {
 	border: 1px solid #5b992b;
 	border-bottom: 1px solid #538c27;
 	box-shadow: inset 0 0 8px 4px #548c29, 0 1px 0 0 #eeeeee;
+}
+
+div.actionlink-container {
+	float: right;
 }
 
 input[type=search], input[type=submit], input[type=button] {

--- a/primerpedia.js
+++ b/primerpedia.js
@@ -96,6 +96,10 @@ function clearNode(node) {
 	return clone;
 }
 
+function getShareableLink(search) {
+	return window.location.pathname + "?search=" + search;
+}
+
 function renderSearchResult(jsonObject) {
 	var pageid = jsonObject.query.pageids[0];
 	var article = jsonObject.query.pages[pageid];
@@ -160,7 +164,7 @@ function addToBrowserHistory(jsonObject) {
 		return;
 	}
 
-	history.pushState(historyState, window.title, window.location.pathname + "?search=" + search);
+	history.pushState(historyState, window.title, getShareableLink(search));
 }
 
 function handleRequestResult(jsonObject) {

--- a/primerpedia.js
+++ b/primerpedia.js
@@ -34,7 +34,7 @@ var articleTitleElement = null;
 var licenseIconElement = null;
 var infoIconElement = null;
 var copyShareLinkInputElement = null;
-var copyModal = null;
+var copyInputContainer = null;
 
 function random() {
 	searchTermInputElement.value = "";
@@ -235,7 +235,7 @@ window.onload = function () {
 	licenseIconElement = document.getElementById("license-icon");
 	infoIconElement = document.getElementById("info-icon");
 	copyShareLinkInputElement = document.getElementById("copyShareLinkInput");
-	copyModal = document.getElementById("copyModal");
+	copyInputContainer = document.getElementById("copyInputContainer");
 
 	var queryParam = getQueryVariable("search");
 
@@ -262,7 +262,10 @@ window.onload = function () {
 	copyShareLinkElement.addEventListener("click", function () {
 		// this should allways be true, but doesn't hurt to check
 		if(copyShareLinkInputElement instanceof HTMLInputElement) {
-			toggleVisibility(copyModal, true);
+			// some browsers require a visible source for selection & copy to work
+			// this container virtually stays invisible
+			// since we hide it again as soon as we are done executing the copy instruction
+			toggleVisibility(copyInputContainer, true);
 
 			// clipboard interaction is a dodgy thing
 			// this should prevent the worst things where browser support
@@ -273,7 +276,7 @@ window.onload = function () {
 			} catch(e) {
 			}
 
-			toggleVisibility(copyModal, false);
+			toggleVisibility(copyInputContainer, false);
 		}
 	});
 };

--- a/primerpedia.js
+++ b/primerpedia.js
@@ -29,9 +29,12 @@ var searchButton = null;
 var contentDivElement = null;
 var viewLinkElem = null;
 var editLinkElement = null;
+var copyShareLinkElement = null;
 var articleTitleElement = null;
 var licenseIconElement = null;
 var infoIconElement = null;
+var copyShareLinkInputElement = null;
+var copyModal = null;
 
 function random() {
 	searchTermInputElement.value = "";
@@ -103,14 +106,18 @@ function getShareableLink(search) {
 function renderSearchResult(jsonObject) {
 	var pageid = jsonObject.query.pageids[0];
 	var article = jsonObject.query.pages[pageid];
-	article.url = "https://en.wikipedia.org/wiki/" + encodeURIComponent(article.title);
+	var encodedArticleTitle = encodeURIComponent(article.title);
+	article.url = "https://en.wikipedia.org/wiki/" + encodedArticleTitle;
 	var editlink = article.url + "?action=edit&amp;section=0";
+	var shareLink = window.location.href;
 
 	viewLinkElem.textContent = article.title;
 	viewLinkElem.setAttribute("href", article.url);
 
 	editLinkElement.setAttribute("href", editlink);
 	toggleVisibility(articleTitleElement, true);
+
+	copyShareLinkInputElement.value = getShareableLink(encodedArticleTitle);
 
 	contentDivElement = clearNode(contentDivElement);
 	contentDivElement.innerHTML = article.extract;
@@ -223,9 +230,12 @@ window.onload = function () {
 	contentDivElement = document.getElementById("content");
 	viewLinkElem = document.getElementById("viewlink");
 	editLinkElement = document.getElementById("editlink");
+	copyShareLinkElement = document.getElementById("copysharelink");
 	articleTitleElement = document.getElementById("article-title");
 	licenseIconElement = document.getElementById("license-icon");
 	infoIconElement = document.getElementById("info-icon");
+	copyShareLinkInputElement = document.getElementById("copyShareLinkInput");
+	copyModal = document.getElementById("copyModal");
 
 	var queryParam = getQueryVariable("search");
 
@@ -249,6 +259,23 @@ window.onload = function () {
 		updateSearchButtonEnabledState();
 	});
 
+	copyShareLinkElement.addEventListener("click", function () {
+		// this should allways be true, but doesn't hurt to check
+		if(copyShareLinkInputElement instanceof HTMLInputElement) {
+			toggleVisibility(copyModal, true);
+
+			// clipboard interaction is a dodgy thing
+			// this should prevent the worst things where browser support
+			// or permissions are missing
+			try {
+				copyShareLinkInputElement.select(); // select the contents of the input
+				document.execCommand("copy"); // copy the selection into the clipboard
+			} catch(e) {
+			}
+
+			toggleVisibility(copyModal, false);
+		}
+	});
 };
 
 window.onpopstate = function () {


### PR DESCRIPTION
[**Preview link**](http://rawgit.com/waldyrious/primerpedia/permalink/index.html)

This is a first step for implementing #23 . And as far as I can see all the functionality is there. One might call this: the minimum viable product :)

I put the "copy shareable link" button beside the existing "edit article" link and choose an appropriate UTF-8 symbol (however I think both edit link and copy share link should get dedicated svgs if I'm honest).

I would really like to use a modal dialog similar to the one github uses but I think this would add almost as much code as the rest of primerpedia itself. Css is not my strength, do you have any input @waldyrious ?