### PR TITLE
53 copy link confirm

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,9 @@
 </head>
 
 <body>
+    <div id="notification" class="information" style="display:none">
+        <a id="notification-content" title="click to dismiss">Successfully copied Shareable Link!</a>
+    </div>
     <h1>
         <a href="index.html">Primerpedia</a>
     </h1>

--- a/primerpedia.css
+++ b/primerpedia.css
@@ -11,6 +11,23 @@ body, h2, .error {
 	text-align: center;
 }
 
+#notification {
+	position: fixed;
+	top: 0;
+	left: 0;
+	width: 100%;
+    padding: 0.5em 1em;
+    box-sizing: border-box;
+}
+
+#notification.information {
+	background-color: LightGreen;
+}
+
+#notification-content {
+	color: initial;
+}
+
 #controls, #content, #article-title {
 	margin: 0.5em auto;
 	width: 80%;

--- a/primerpedia.js
+++ b/primerpedia.js
@@ -23,7 +23,11 @@ var apiUrl = "https://en.wikipedia.org/w/api.php?";
 var apiExtractsQuery = "action=query&prop=extracts&exintro&indexpageids=true&format=json";
 var requestTimeoutInMs = 3000;
 var requestCallbackName = "requestCallback";
+var notificationTimeoutInMs = 3000;
+var notificationTimeout = null;
 
+var notificationElement = null;
+var notificationContentElement = null;
 var searchTermInputElement = null;
 var searchButton = null;
 var contentDivElement = null;
@@ -230,6 +234,8 @@ function updateSearchButtonEnabledState() {
 
 // Upon loading the page, check if an URL parameter was passed, and use it to perform a search
 window.onload = function () {
+    notificationElement = document.getElementById("notification");
+    notificationContentElement = document.getElementById("notification-content");
     searchTermInputElement = document.getElementById("search-term");
     searchButton = document.getElementById("searchButton");
     contentDivElement = document.getElementById("content");
@@ -278,11 +284,21 @@ window.onload = function () {
             try {
                 copyShareLinkInputElement.select(); // select the contents of the input
                 document.execCommand("copy"); // copy the selection into the clipboard
+
+                toggleVisibility(notificationElement, true); // show notification to user
+                // hide notification after an agreeable time
+                setTimeout(function () {
+                    toggleVisibility(notificationElement, false); //
+                }, notificationTimeoutInMs);
             } catch(e) {
             }
 
             toggleVisibility(copyInputContainer, false);
         }
+    });
+
+    notificationContentElement.addEventListener("click", function () {
+        toggleVisibility(notificationElement, false);
     });
 };
 


### PR DESCRIPTION
<!-- Thank you for contributing to the Primerpedia project! -->
<!-- If applicable, please use the following URL template to provide a preview of the changes: -->

➡ [**Live preview of the changes**](http://rawgit.com/waldyrious/primerpedia/53-copy-link-confirm/index.html)

This resolves #53 .

After playing around with animating the Notification Bar I found that every nice looking solution added about 20% more CSS which I don't think is actually worth it.

So this will only show the link, wait for the predefined time (3 seconds I guess is a tad long) and then hide itself.